### PR TITLE
조서림 / 6주차 / 4문제

### DIFF
--- a/조서림/week 6/BOJ 1240.py
+++ b/조서림/week 6/BOJ 1240.py
@@ -1,0 +1,27 @@
+import sys
+from collections import deque
+
+n, m = map(int, sys.stdin.readline().split())
+tree = [[] for _ in range(n+1)]
+for _ in range(n-1):
+    x, y, k = map(int, sys.stdin.readline().split())
+    tree[x].append((y, k))
+    tree[y].append((x, k))
+
+def bfs(v):
+    queue = deque([(v, 0)])
+    visited = [False] * (n+1)
+    visited[v] = True
+    
+    while len(queue) > 0:
+        curr, dist = queue.popleft()
+        if curr == target: return dist
+        
+        for next, d in tree[curr]:
+            if not visited[next]:
+                queue.append((next, d+dist))
+                visited[next] = True
+
+for _ in range(m):
+    start, target = map(int, sys.stdin.readline().split())
+    print(bfs(start))

--- a/조서림/week 6/BOJ 1260.py
+++ b/조서림/week 6/BOJ 1260.py
@@ -1,0 +1,35 @@
+import sys
+
+n, m, v = map(int, sys.stdin.readline().split())
+nodes = [[0] * (n+1) for _ in range(n+1)]
+for _ in range(m):
+    x, y = map(int, sys.stdin.readline().split())
+    nodes[x][y] = nodes[y][x] = 1
+
+def dfs(visited, v):
+    if not visited[v]:
+        print(v, end=' ')
+        visited[v] = True
+    
+    for i in range(1, n+1):
+        if nodes[v][i] == 1 and not visited[i]:
+            dfs(visited, i)
+
+def bfs(v):
+    visited = [False] * (n+1)
+    visited[v] = True
+    queue = [v]
+    
+    while len(queue) > 0:
+        curr = queue.pop(0)
+        print(curr, end=' ')
+        
+        for i in range(1, n+1):
+            if nodes[curr][i] == 1 and not visited[i]:
+                queue.append(i)
+                visited[i] = True
+            
+visited = [False] * (n+1)
+dfs(visited, v)
+print()
+bfs(v)

--- a/조서림/week 6/BOJ 2178.py
+++ b/조서림/week 6/BOJ 2178.py
@@ -1,0 +1,24 @@
+import sys
+
+n, m = map(int, sys.stdin.readline().split())
+maze = [list(map(int, list(sys.stdin.readline().strip()))) for _ in range(n)]
+
+def bfs():
+    queue = [(0, 0, 1)]
+    visited = [[False] * m for _ in range(n)]
+    visited[0][0] = True
+    directions = [(-1,0),(1,0),(0,-1),(0,1)]
+    
+    while queue:
+        x, y, dist = queue.pop(0)
+        
+        if x == n-1 and y == m-1: return dist
+        
+        for dx, dy in directions:
+            a = x+dx
+            b = y+dy
+            if (0 <= a < n and 0 <= b < m) and maze[a][b] == 1 and not visited[a][b]:
+                visited[a][b] = True
+                queue.append((a, b, dist+1))
+                
+print(bfs())

--- a/조서림/week 6/BOJ 4963.py
+++ b/조서림/week 6/BOJ 4963.py
@@ -1,0 +1,28 @@
+import sys
+sys.setrecursionlimit(10**6)
+
+while True:
+    w, h = map(int, sys.stdin.readline().split())
+    if w == 0 and h == 0: break
+    land = [list(map(int, sys.stdin.readline().split())) for _ in range(h)]
+    
+    check = [[False] * w for _ in range(h)]
+    directions = [(-1,0),(-1,-1),(0,-1),(1,-1),(1,0),(1,1),(0,1),(-1,1)]
+    
+    def dfs(x, y):
+        if land[x][y] == 1 and not check[x][y]:
+            check[x][y] = True
+        
+        for dx, dy in directions:
+            a = x+dx
+            b = y+dy
+            if (0 <= a < h and 0 <= b < w) and land[a][b] == 1 and not check[a][b]:
+                dfs(a, b)
+    
+    cnt = 0    
+    for i in range(h):
+        for j in range(w):
+            if land[i][j] == 1 and not check[i][j]:
+                dfs(i, j)
+                cnt += 1
+    print(cnt)


### PR DESCRIPTION
- 1260 : 얼마 전에 풀었음
- 4963 : 전에 했던 유기농 배추 문제와 동일하여 쉽게 해결


- 1240 : 처음에 dfs로 시도했는데 path를 저장하고 옳은 길이 아니면 제거하는 식으로 구현했으나 시간초과가 발생했고, path를 저장하지 않고 해결하는 방식을 모르겠어서 bfs로 변경.
(인터넷 참고) bfs에서도 옳은 길이 아닐 때 처리하는 데 어려움이 있어 다음 방문할 노드와 거리를 함께 큐에 저장하는 방식으로 해결. bfs로 변경해도 시간초과가 발생해 인접 행렬 방식에서 인접 리스트 방식으로 변경.

- 2178 : 최단거리를 보고 bfs로 해결. 1240을 풀 때와 같이 큐에 다음 방문할 좌표와 거리를 함께 저장.
문제 해결 후, 인터넷을 참고하여 특정 좌표까지의 최단 거리를 미로에 직접 기록하는 식으로 더 쉽게 해결 가능한 것을 알게 됨.